### PR TITLE
Fix the returned location of packages.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.thoughtworks.go</groupId>
     <artifactId>deb-repo-poller</artifactId>
-    <version>1.2</version>
+    <version>1.3</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/com/tw/go/plugin/material/artifactrepository/deb/model/RepoUrl.java
+++ b/src/com/tw/go/plugin/material/artifactrepository/deb/model/RepoUrl.java
@@ -102,25 +102,15 @@ public class RepoUrl {
     }
 
     public String getPackageLocation(String filePath) {
-        String packageLocation = null;
-        if (url.endsWith("/"))
-            packageLocation = url.substring(0, url.length() - 1);
-        else
-            packageLocation = url;
-        String[] parts = filePath.split("/");
-        for (int i = 0; i < parts.length; i++) {
-            if (!packageLocation.contains(parts[i])) {
-                packageLocation = merge(packageLocation, parts, i);
-                break;
-            }
-        }
-        return packageLocation;
-    }
+        String packageLocation = url;
+        // For repo http://in.archive.ubuntu.com/ubuntu/dists/trusty/main/binary-amd64/
+        // packages will be located under http://in.archive.ubuntu.com/ubuntu/pool/...,
+        // so truncate the package_location to http://in.archive.ubuntu.com/ubuntu and 
+        // append the filename.
 
-    private String merge(String packageLocation, String[] parts, int index) {
-        for (int i = index; i < parts.length; i++) {
-            packageLocation += "/" + parts[i];
-        }
+        int truncateIndex = url.indexOf("dists");
+        packageLocation = packageLocation.substring(0, truncateIndex);
+        packageLocation += filePath;
         return packageLocation;
     }
 }

--- a/test/com/tw/go/plugin/material/artifactrepository/deb/model/RepoUrlTest.java
+++ b/test/com/tw/go/plugin/material/artifactrepository/deb/model/RepoUrlTest.java
@@ -101,8 +101,8 @@ public class RepoUrlTest {
 
     @Test
     public void shouldNotThrowExceptionIfCheckConnectionToTheRepoPasses() {
-        new RepoUrl("http://in.archive.ubuntu.com/ubuntu/dists/saucy/main/binary-amd64/", null, null).checkConnection();
-        new RepoUrl("http://in.archive.ubuntu.com/ubuntu/dists/saucy/main/binary-amd64", null, null).checkConnection();
+        new RepoUrl("http://in.archive.ubuntu.com/ubuntu/dists/trusty/main/binary-amd64/", null, null).checkConnection();
+        new RepoUrl("http://in.archive.ubuntu.com/ubuntu/dists/trusty/main/binary-amd64", null, null).checkConnection();
     }
 
     @Test
@@ -115,6 +115,14 @@ public class RepoUrlTest {
         assertThat(new RepoUrl("file:///foo/bar", null, null).getRepoMetadataUrl(), is("file:///foo/bar/Packages.gz"));
         assertThat(new RepoUrl("file:///foo/bar/", null, null).getRepoMetadataUrl(), is("file:///foo/bar/Packages.gz"));
         assertThat(new RepoUrl("file:///foo/bar//", null, null).getRepoMetadataUrl(), is("file:///foo/bar/Packages.gz"));
+    }
+
+    @Test
+    public void shouldGetCorrectPathGetPackageLocation() throws Exception {
+        assertThat(
+            new RepoUrl("http://in.archive.ubuntu.com/ubuntu/dists/trusty/main/binary-amd64/", null, null).getPackageLocation("pool/main/e/empathy/account-plugin-aim_3.8.6-0ubuntu9_amd64.deb"), 
+            is("http://in.archive.ubuntu.com/ubuntu/pool/main/e/empathy/account-plugin-aim_3.8.6-0ubuntu9_amd64.deb")
+        );
     }
 
     private void assertRepositoryUrlValidation(String url, String username, String password, List<ValidationError> expectedErrors, boolean isSuccessful) {


### PR DESCRIPTION
A request to http://in.archive.ubuntu.com/ubuntu/dists/trusty/main/binary-amd64/ for
package account-plugin-aim_3.8.6-0ubuntu9_amd64.deb shoudl return a file location of
http://in.archive.ubuntu.com/ubuntu/pool/main/e/empathy/account-plugin-aim_3.8.6-0ubuntu9_amd64.deb

The existing file location returned was incorrectly returning:
http://in.archive.ubuntu.com/ubuntu/dists/trusty/main/binary-amd64/pool/main/e/empathy/account-plugin-aim_3.8.6-0ubuntu9_amd64.deb

Unit test has been included as well as updating test that pointed at saucy repo (no longer there) to point at trusty.

closes #6